### PR TITLE
feat(db): Add persistent storage with SQLModel

### DIFF
--- a/scripts/seed_db.py
+++ b/scripts/seed_db.py
@@ -1,0 +1,53 @@
+"""Seed the database with initial activities data."""
+import os
+import sys
+from pathlib import Path
+from sqlmodel import Session, create_engine, select, SQLModel
+
+# Ensure `src` is on path for imports when running this script directly
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+from models import Activity
+
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///./data.db")
+engine = create_engine(DATABASE_URL)
+
+
+INITIAL_ACTIVITIES = [
+    {
+        "name": "Chess Club",
+        "description": "Learn strategies and compete in chess tournaments",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 12,
+    },
+    {
+        "name": "Programming Class",
+        "description": "Learn programming fundamentals and build software projects",
+        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 20,
+    },
+    {
+        "name": "Gym Class",
+        "description": "Physical education and sports activities",
+        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+        "max_participants": 30,
+    },
+]
+
+
+def seed():
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        for a in INITIAL_ACTIVITIES:
+            exists = session.exec(
+                select(Activity).where(Activity.name == a["name"])  # type: ignore
+            ).first()
+            if not exists:
+                act = Activity(**a)
+                session.add(act)
+        session.commit()
+
+
+if __name__ == "__main__":
+    seed()

--- a/src/app.py
+++ b/src/app.py
@@ -1,81 +1,39 @@
 """
-High School Management System API
+High School Management System API (DB-backed)
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
+This version uses SQLModel for persistence. It reads `DATABASE_URL` from the
+environment. If not provided, it falls back to a local SQLite file for
+development convenience.
 """
+
+import os
+from pathlib import Path
+from typing import List
 
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
-import os
-from pathlib import Path
+
+from sqlmodel import Session, select, create_engine
+
+from .models import SQLModel, Activity, Participant
+
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
-# Mount the static files directory
-current_dir = Path(__file__).parent
-app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
-          "static")), name="static")
+# Mount static files
+app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent, "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+# Database setup
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///./data.db")
+engine = create_engine(DATABASE_URL, echo=False)
+
+
+@app.on_event("startup")
+def on_startup():
+    # create tables if they don't exist
+    SQLModel.metadata.create_all(engine)
 
 
 @app.get("/")
@@ -85,48 +43,57 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    with Session(engine) as session:
+        activities = session.exec(select(Activity)).all()
+        result = {}
+        for act in activities:
+            participants = [p.email for p in act.participants]
+            result[act.name] = {
+                "description": act.description,
+                "schedule": act.schedule,
+                "max_participants": act.max_participants,
+                "participants": participants,
+            }
+        return result
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with Session(engine) as session:
+        statement = select(Activity).where(Activity.name == activity_name)
+        activity = session.exec(statement).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        # Load participants count
+        current = len(activity.participants)
+        if any(p.email == email for p in activity.participants):
+            raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+        if activity.max_participants and current >= activity.max_participants:
+            raise HTTPException(status_code=400, detail="Activity is full")
 
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+        participant = Participant(email=email, activity_id=activity.id)
+        session.add(participant)
+        session.commit()
+        session.refresh(participant)
+        return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with Session(engine) as session:
+        statement = select(Activity).where(Activity.name == activity_name)
+        activity = session.exec(statement).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        participant_stmt = select(Participant).where(Participant.activity_id == activity.id, Participant.email == email)
+        participant = session.exec(participant_stmt).first()
+        if not participant:
+            raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
+        session.delete(participant)
+        session.commit()
+        return {"message": f"Unregistered {email} from {activity_name}"}
 
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,18 @@
+from typing import List, Optional
+from sqlmodel import SQLModel, Field, Relationship
+
+
+class Participant(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    email: str = Field(index=True)
+    activity_id: Optional[int] = Field(default=None, foreign_key="activity.id")
+    activity: Optional["Activity"] = Relationship(back_populates="participants")
+
+
+class Activity(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True, unique=True)
+    description: Optional[str] = None
+    schedule: Optional[str] = None
+    max_participants: int = 0
+    participants: List[Participant] = Relationship(back_populates="activity")


### PR DESCRIPTION
This PR adds SQLModel models and switches API endpoints to use a database-backed storage. It also includes a simple seed script.

Notes:
- DB URL is read from the `DATABASE_URL` env var (defaults to `sqlite:///./data.db`).
- Add `sqlmodel` and `psycopg2-binary` to your environment before running.
